### PR TITLE
Add: qmkbuilder

### DIFF
--- a/keyboards.json
+++ b/keyboards.json
@@ -204,5 +204,24 @@
     "firmware_targets": [],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "capsicain",
+    "repo": "https://github.com/cajhin/capsicain",
+    "homepage": "",
+    "image": "https://opengraph.githubassets.com/1/cajhin/capsicain",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [
+      "QMK"
+    ],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -223,5 +223,24 @@
     ],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "qmkbuilder",
+    "repo": "https://github.com/ruiqimao/qmkbuilder",
+    "homepage": "http://kbfirmware.com",
+    "image": "https://opengraph.githubassets.com/1/ruiqimao/qmkbuilder",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [
+      "QMK"
+    ],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -184,5 +184,25 @@
     "firmware_targets": [],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "scottokeebs",
+    "repo": "https://github.com/joe-scotto/scottokeebs",
+    "homepage": "https://scottokeebs.com",
+    "image": "https://github.com/joe-scotto/scottokeebs/assets/8194147/d13ea430-0d15-4b06-acb6-fe8aa295f84d",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [
+      "pico",
+      "pro-micro"
+    ],
+    "firmware_targets": [],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -167,5 +167,22 @@
     "case": "3D Print",
     "link": "https://github.com/duckyb/urchin",
     "image": "https://github.com/duckyb/urchin/raw/main/gallery/case/coral/urchin-coral.jpg"
+  },
+  {
+    "name": "qmk_firmware",
+    "repo": "https://github.com/qmk/qmk_firmware",
+    "homepage": "https://qmk.fm",
+    "image": "https://opengraph.githubassets.com/1/qmk/qmk_firmware",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]


### PR DESCRIPTION
Auto-imported from GitHub search.

- Repo: https://github.com/ruiqimao/qmkbuilder
- Layout base: row-stagger
- Form factors: 
- Splay: False
- Unibody: False
- Keys: None (alts: [])
- Controller onboard: None
- Footprints: 
- Firmware: QMK
- Image: https://opengraph.githubassets.com/1/ruiqimao/qmkbuilder