### PR TITLE
Add: arsenik

### DIFF
--- a/keyboards.json
+++ b/keyboards.json
@@ -261,5 +261,27 @@
     ],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "arsenik",
+    "repo": "https://github.com/OneDeadKey/arsenik",
+    "homepage": "",
+    "image": "https://opengraph.githubassets.com/1/OneDeadKey/arsenik",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": 33,
+    "keys_alt": [
+      34,
+      36
+    ],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [
+      "QMK"
+    ],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]


### PR DESCRIPTION
Auto-imported from GitHub search.

- Repo: https://github.com/OneDeadKey/arsenik
- Layout base: row-stagger
- Form factors: 
- Splay: False
- Unibody: False
- Keys: 33 (alts: [34, 36])
- Controller onboard: None
- Footprints: 
- Firmware: QMK
- Image: https://opengraph.githubassets.com/1/OneDeadKey/arsenik