### PR TITLE
Add: steno

### DIFF
--- a/keyboards.json
+++ b/keyboards.json
@@ -204,5 +204,24 @@
     "firmware_targets": [],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "capsicain",
+    "repo": "https://github.com/cajhin/capsicain",
+    "homepage": "",
+    "image": "https://opengraph.githubassets.com/1/cajhin/capsicain",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [
+      "QMK"
+    ],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -223,5 +223,24 @@
     ],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "qmkbuilder",
+    "repo": "https://github.com/ruiqimao/qmkbuilder",
+    "homepage": "http://kbfirmware.com",
+    "image": "https://opengraph.githubassets.com/1/ruiqimao/qmkbuilder",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [
+      "QMK"
+    ],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -184,5 +184,25 @@
     "firmware_targets": [],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "scottokeebs",
+    "repo": "https://github.com/joe-scotto/scottokeebs",
+    "homepage": "https://scottokeebs.com",
+    "image": "https://github.com/joe-scotto/scottokeebs/assets/8194147/d13ea430-0d15-4b06-acb6-fe8aa295f84d",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [
+      "pico",
+      "pro-micro"
+    ],
+    "firmware_targets": [],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -167,5 +167,22 @@
     "case": "3D Print",
     "link": "https://github.com/duckyb/urchin",
     "image": "https://github.com/duckyb/urchin/raw/main/gallery/case/coral/urchin-coral.jpg"
+  },
+  {
+    "name": "qmk_firmware",
+    "repo": "https://github.com/qmk/qmk_firmware",
+    "homepage": "https://qmk.fm",
+    "image": "https://opengraph.githubassets.com/1/qmk/qmk_firmware",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -242,5 +242,24 @@
     ],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "miryoku_qmk",
+    "repo": "https://github.com/manna-harbour/miryoku_qmk",
+    "homepage": "https://github.com/manna-harbour/miryoku_qmk/tree/miryoku/users/manna-harbour_miryoku",
+    "image": "https://opengraph.githubassets.com/1/manna-harbour/miryoku_qmk",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [
+      "QMK"
+    ],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -261,5 +261,27 @@
     ],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "arsenik",
+    "repo": "https://github.com/OneDeadKey/arsenik",
+    "homepage": "",
+    "image": "https://opengraph.githubassets.com/1/OneDeadKey/arsenik",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": 33,
+    "keys_alt": [
+      34,
+      36
+    ],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [
+      "QMK"
+    ],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -283,5 +283,24 @@
     ],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "tp78_v2",
+    "repo": "https://github.com/ChnMasterOG/tp78_v2",
+    "homepage": "https://www.bilibili.com/video/BV1Ho4y1b78t",
+    "image": "https://opengraph.githubassets.com/1/ChnMasterOG/tp78_v2",
+    "layout_base": "row-stagger",
+    "form_factors": [
+      "split"
+    ],
+    "splay": false,
+    "unibody": false,
+    "keys": null,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]

--- a/keyboards.json
+++ b/keyboards.json
@@ -302,5 +302,24 @@
     "firmware_targets": [],
     "source": "github-search",
     "last_checked": "2025-08-08"
+  },
+  {
+    "name": "steno",
+    "repo": "https://github.com/crides/steno",
+    "homepage": "",
+    "image": "https://opengraph.githubassets.com/1/crides/steno",
+    "layout_base": "row-stagger",
+    "form_factors": [],
+    "splay": false,
+    "unibody": false,
+    "keys": 23,
+    "keys_alt": [],
+    "controller_onboard": null,
+    "controller_footprint": [],
+    "firmware_targets": [
+      "QMK"
+    ],
+    "source": "github-search",
+    "last_checked": "2025-08-08"
   }
 ]


### PR DESCRIPTION
Auto-imported from GitHub search.

- Repo: https://github.com/crides/steno
- Layout base: row-stagger
- Form factors: 
- Splay: False
- Unibody: False
- Keys: 23 (alts: [])
- Controller onboard: None
- Footprints: 
- Firmware: QMK
- Image: https://opengraph.githubassets.com/1/crides/steno